### PR TITLE
Capybara matchers

### DIFF
--- a/lib/rspec/rails/example/cell_example_group.rb
+++ b/lib/rspec/rails/example/cell_example_group.rb
@@ -18,9 +18,14 @@ module RSpec::Rails
 
     capybara do
       include Capybara
+      begin
+        include Capybara::RSpec::StringMatchers
+      rescue NameError
+        # Read more in the source file
+        require 'rspec_cells/capybara/string_matchers'
+        include RSpecCells::Capybara::StringMatchers
+      end
     end
-
-
 
     module InstanceMethods
       attr_reader :controller, :routes

--- a/lib/rspec_cells/capybara/string_matchers.rb
+++ b/lib/rspec_cells/capybara/string_matchers.rb
@@ -1,0 +1,45 @@
+# This includes a backported version of the Capybara string matchers David Chelimsky
+# is preparing in https://github.com/dchelimsky/capybara/tree/rspec-matchers
+#
+# Looks like the string matchers will be included in Capybara 0.4.2 if the feature is ready.
+#
+# The branch have not being merged into master because it's missing support for the capybara
+# page object.
+#
+# When we test a rendered cell with the `render_cell` method we get an ActionView::OutputBuffer
+# instance, it is in short, a safe version of String, so we are testing a String, not a capybara
+# page object. So the matchers are OK and the missing features won't bother us.
+#
+# Follow up in http://groups.google.com/group/ruby-capybara/browse_thread/thread/c8adaa8f750b1020
+module RSpecCells
+  module Capybara
+    module StringMatchers
+      extend ::RSpec::Matchers::DSL
+
+      %w[css xpath selector].each do |type|
+        matcher "have_#{type}" do |*args|
+          match_for_should do |string|
+            ::Capybara::string(string).send("has_#{type}?", *args)
+          end
+
+          match_for_should_not do |string|
+            ::Capybara::string(string).send("has_no_#{type}?", *args)
+          end
+
+          failure_message_for_should do |string|
+            "expected #{type} #{formatted(args)} to return something from:\n#{string}"
+          end
+
+          failure_message_for_should_not do |string|
+            "expected #{type} #{formatted(args)} not to return anything from:\n#{string}"
+          end
+
+          def formatted(args)
+            args.length == 1 ? args.first.inspect : args.inspect
+          end
+        end
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Backported from a future version of Capybara, string matchers so we can spec the result of render_cell method with has_selector? has_css? and has_xpath? matchers. Read the module source file for more information
