### PR TITLE
Generate proper spec for namespaced cell

### DIFF
--- a/lib/generators/rspec/cell_generator.rb
+++ b/lib/generators/rspec/cell_generator.rb
@@ -5,8 +5,12 @@ module Rspec
     class CellGenerator < ::Cells::Generators::Base
       source_root File.expand_path('../templates', __FILE__)
 
+      def cell_name
+        class_path.empty? ? ":#{file_path}" : %{"#{file_path}"}
+      end
+
       def create_cell_spec_file
-        template "cell_spec.erb", File.join("spec/cells/#{file_name}_cell_spec.rb")
+        template "cell_spec.erb", File.join("spec/cells/#{file_path}_cell_spec.rb")
       end
     end
   end

--- a/lib/generators/rspec/templates/cell_spec.erb
+++ b/lib/generators/rspec/templates/cell_spec.erb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe <%= class_name %>Cell do
 
   context "cell instance" do
-    subject { cell(:<%= file_name %>) }
+    subject { cell(<%= cell_name %>) }
 
     <%- for state in actions -%>
     it { should respond_to(:<%= state %>) }
@@ -13,14 +13,14 @@ describe <%= class_name %>Cell do
   context "cell rendering" do
   <%- actions.each_with_index do |state, index| -%>
     context "rendering <%= state %>" do
-      subject { render_cell(:<%= file_name %>, :<%= state %>) }
+      subject { render_cell(<%= cell_name %>, :<%= state %>) }
 
       <%- if defined?(Capybara) -%>
       it { should have_selector("h1", :text => "<%= class_name %>#<%= state %>") }
-      it { should have_selector("p", :text => "Find me in app/cells/<%= file_name %>/<%= state %>.html") }
+      it { should have_selector("p", :text => "Find me in app/cells/<%= file_path %>/<%= state %>.html") }
       <%- else -%>
       it { should have_selector("h1", :content => "<%= class_name %>#<%= state %>") }
-      it { should have_selector("p", :content => "Find me in app/cells/<%= file_name %>/<%= state %>.html") }
+      it { should have_selector("p", :content => "Find me in app/cells/<%= file_path %>/<%= state %>.html") }
       <%- end -%>
     end
     <%- unless index == actions.length - 1 -%>

--- a/spec/cells/cell_generator_spec.rb
+++ b/spec/cells/cell_generator_spec.rb
@@ -102,4 +102,48 @@ describe Rspec::Generators::CellGenerator do
       test.assert_file "spec/cells/twitter_cell_spec.rb", t('end')
     end
   end
+
+  context "When uses namespace" do
+
+    before(:all) do
+      test.run_generator %w(Forum::Comment display form)
+    end
+
+    after(:all) do
+      FileUtils.rm_rf(DESTINATION_ROOT) # Cleanup after we are done testing
+    end
+
+    GENERATED_FILE = "spec/cells/forum/comment_cell_spec.rb"
+
+    it 'creates respond_to states specs' do
+      test.assert_file GENERATED_FILE, t('context "cell instance" do')
+      test.assert_file GENERATED_FILE, t('subject { cell("forum/comment") }')
+      test.assert_file GENERATED_FILE, t('it { should respond_to(:display) }')
+      test.assert_file GENERATED_FILE, t('it { should respond_to(:form) }')
+      test.assert_file GENERATED_FILE, t('end')
+    end
+
+    it "creates widget spec" do
+      test.assert_file GENERATED_FILE, t("require 'spec_helper'")
+      test.assert_file GENERATED_FILE, t('describe Forum::CommentCell do')
+      test.assert_file GENERATED_FILE, t('context "cell rendering" do')
+      test.assert_file GENERATED_FILE, t('end')
+    end
+
+    it 'creates display state' do
+      test.assert_file GENERATED_FILE, t('context "rendering display" do')
+      test.assert_file GENERATED_FILE, t('subject { render_cell("forum/comment", :display) }')
+      test.assert_file GENERATED_FILE, t('it { should have_selector("h1", :content => "Forum::Comment#display") }')
+      test.assert_file GENERATED_FILE, t('it { should have_selector("p", :content => "Find me in app/cells/forum/comment/display.html") }')
+      test.assert_file GENERATED_FILE, t('end')
+    end
+
+    it 'creates form state' do
+      test.assert_file GENERATED_FILE, t('context "rendering form" do')
+      test.assert_file GENERATED_FILE, t('subject { render_cell("forum/comment", :form) }')
+      test.assert_file GENERATED_FILE, t('it { should have_selector("h1", :content => "Forum::Comment#form") }')
+      test.assert_file GENERATED_FILE, t('it { should have_selector("p", :content => "Find me in app/cells/forum/comment/form.html") }')
+      test.assert_file GENERATED_FILE, t('end')
+    end
+  end
 end


### PR DESCRIPTION
Specs support namespaced cells same as Unit Tests https://github.com/apotonick/cells/pull/113 .
All rspec-cells's specs pass. Generated spec works as well as I've tested it with real Rails project spec suite.
