### PR TITLE
fix #26: generator not generating capybara matcher

### DIFF
--- a/lib/generators/rspec/cell_generator.rb
+++ b/lib/generators/rspec/cell_generator.rb
@@ -1,5 +1,8 @@
 require 'generators/cells/base'
 
+# ensure that we can see the test-libraries like Capybara
+Bundler.require :test if Bundler
+
 module Rspec
   module Generators
     class CellGenerator < ::Cells::Generators::Base


### PR DESCRIPTION
issue occured when rspec-cells is only in test group.
