### PR TITLE
have_selector replacement when capybara not installed

### DIFF
--- a/lib/generators/rspec/templates/cell_spec.erb
+++ b/lib/generators/rspec/templates/cell_spec.erb
@@ -19,8 +19,8 @@ describe <%= class_name %>Cell do
       it { should have_selector("h1", :text => "<%= class_name %>#<%= state %>") }
       it { should have_selector("p", :text => "Find me in app/cells/<%= file_path %>/<%= state %>.html") }
       <%- else -%>
-      it { should have_selector("h1", :content => "<%= class_name %>#<%= state %>") }
-      it { should have_selector("p", :content => "Find me in app/cells/<%= file_path %>/<%= state %>.html") }
+      it { should include "<%= class_name %>#<%= state %>" }
+      it { should include "Find me in app/cells/<%= file_path %>/<%= state %>.html" }
       <%- end -%>
     end
     <%- unless index == actions.length - 1 -%>

--- a/spec/cells/cell_generator_spec.rb
+++ b/spec/cells/cell_generator_spec.rb
@@ -89,16 +89,16 @@ describe Rspec::Generators::CellGenerator do
     it 'creates display state' do
       test.assert_file "spec/cells/twitter_cell_spec.rb", t('context "rendering display" do')
       test.assert_file "spec/cells/twitter_cell_spec.rb", t('subject { render_cell(:twitter, :display) }')
-      test.assert_file "spec/cells/twitter_cell_spec.rb", t('it { should have_selector("h1", :content => "Twitter#display") }')
-      test.assert_file "spec/cells/twitter_cell_spec.rb", t('it { should have_selector("p", :content => "Find me in app/cells/twitter/display.html") }')
+      test.assert_file "spec/cells/twitter_cell_spec.rb", t('it { should include "Twitter#display" }')
+      test.assert_file "spec/cells/twitter_cell_spec.rb", t('it { should include "Find me in app/cells/twitter/display.html" }')
       test.assert_file "spec/cells/twitter_cell_spec.rb", t('end')
     end
 
     it 'creates form state' do
       test.assert_file "spec/cells/twitter_cell_spec.rb", t('context "rendering form" do')
       test.assert_file "spec/cells/twitter_cell_spec.rb", t('subject { render_cell(:twitter, :form) }')
-      test.assert_file "spec/cells/twitter_cell_spec.rb", t('it { should have_selector("h1", :content => "Twitter#form") }')
-      test.assert_file "spec/cells/twitter_cell_spec.rb", t('it { should have_selector("p", :content => "Find me in app/cells/twitter/form.html") }')
+      test.assert_file "spec/cells/twitter_cell_spec.rb", t('it { should include "Twitter#form" }')
+      test.assert_file "spec/cells/twitter_cell_spec.rb", t('it { should include "Find me in app/cells/twitter/form.html" }')
       test.assert_file "spec/cells/twitter_cell_spec.rb", t('end')
     end
   end
@@ -133,16 +133,16 @@ describe Rspec::Generators::CellGenerator do
     it 'creates display state' do
       test.assert_file GENERATED_FILE, t('context "rendering display" do')
       test.assert_file GENERATED_FILE, t('subject { render_cell("forum/comment", :display) }')
-      test.assert_file GENERATED_FILE, t('it { should have_selector("h1", :content => "Forum::Comment#display") }')
-      test.assert_file GENERATED_FILE, t('it { should have_selector("p", :content => "Find me in app/cells/forum/comment/display.html") }')
+      test.assert_file GENERATED_FILE, t('it { should include "Forum::Comment#display" }')
+      test.assert_file GENERATED_FILE, t('it { should include "Find me in app/cells/forum/comment/display.html" }')
       test.assert_file GENERATED_FILE, t('end')
     end
 
     it 'creates form state' do
       test.assert_file GENERATED_FILE, t('context "rendering form" do')
       test.assert_file GENERATED_FILE, t('subject { render_cell("forum/comment", :form) }')
-      test.assert_file GENERATED_FILE, t('it { should have_selector("h1", :content => "Forum::Comment#form") }')
-      test.assert_file GENERATED_FILE, t('it { should have_selector("p", :content => "Find me in app/cells/forum/comment/form.html") }')
+      test.assert_file GENERATED_FILE, t('it { should include "Forum::Comment#form" }')
+      test.assert_file GENERATED_FILE, t('it { should include "Find me in app/cells/forum/comment/form.html" }')
       test.assert_file GENERATED_FILE, t('end')
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require 'bundler/setup'
 require "rails/all"
 require 'rspec-cells'
 require 'rspec/rails'
+require 'cell/base'
 require 'cell/test_case'
 require 'rspec/rails/example/cell_example_group'
 


### PR DESCRIPTION
Fix for: https://github.com/apotonick/cells/issues/199
Added `require 'cell/base'` to spec_helper, otherwise `rspec` is falling with:

```
/home/lokson/.rvm/gems/ruby-2.1.1@rspec-cells/gems/cells-3.10.0/lib/cell/test_case.rb:153:in `<class:TestCase>': undefined method `rails4_0?' for Cell:Module (NoMethodError)
    from /home/lokson/.rvm/gems/ruby-2.1.1@rspec-cells/gems/cells-3.10.0/lib/cell/test_case.rb:40:in `<module:Cell>'
    from /home/lokson/.rvm/gems/ruby-2.1.1@rspec-cells/gems/cells-3.10.0/lib/cell/test_case.rb:1:in `<top (required)>'
    from /home/lokson/.rvm/gems/ruby-2.1.1@rspec-cells/gems/activesupport-3.2.12/lib/active_support/dependencies.rb:251:in `require'
    from /home/lokson/.rvm/gems/ruby-2.1.1@rspec-cells/gems/activesupport-3.2.12/lib/active_support/dependencies.rb:251:in `block in require'
    from /home/lokson/.rvm/gems/ruby-2.1.1@rspec-cells/gems/activesupport-3.2.12/lib/active_support/dependencies.rb:236:in `load_dependency'
    from /home/lokson/.rvm/gems/ruby-2.1.1@rspec-cells/gems/activesupport-3.2.12/lib/active_support/dependencies.rb:251:in `require'
    from /home/lokson/rspec-cells/spec/spec_helper.rb:8:in `<top (required)>'
    from /home/lokson/rspec-cells/spec/cells/cell_generator_spec.rb:1:in `require'
    from /home/lokson/rspec-cells/spec/cells/cell_generator_spec.rb:1:in `<top (required)>'
    from /home/lokson/.rvm/gems/ruby-2.1.1@rspec-cells/gems/rspec-core-2.14.8/lib/rspec/core/configuration.rb:896:in `load'
    from /home/lokson/.rvm/gems/ruby-2.1.1@rspec-cells/gems/rspec-core-2.14.8/lib/rspec/core/configuration.rb:896:in `block in load_spec_files'
    from /home/lokson/.rvm/gems/ruby-2.1.1@rspec-cells/gems/rspec-core-2.14.8/lib/rspec/core/configuration.rb:896:in `each'
    from /home/lokson/.rvm/gems/ruby-2.1.1@rspec-cells/gems/rspec-core-2.14.8/lib/rspec/core/configuration.rb:896:in `load_spec_files'
    from /home/lokson/.rvm/gems/ruby-2.1.1@rspec-cells/gems/rspec-core-2.14.8/lib/rspec/core/command_line.rb:22:in `run'
    from /home/lokson/.rvm/gems/ruby-2.1.1@rspec-cells/gems/rspec-core-2.14.8/lib/rspec/core/runner.rb:80:in `run'
    from /home/lokson/.rvm/gems/ruby-2.1.1@rspec-cells/gems/rspec-core-2.14.8/lib/rspec/core/runner.rb:17:in `block in autorun'
```
