### PR TITLE
Drop old version dependency restriction from gemspec

### DIFF
--- a/rspec-cells.gemspec
+++ b/rspec-cells.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency(%q<railties>, ['>= 3.0', '< 4.1'])
-  s.add_runtime_dependency(%q<rspec-rails>, ["~> 2.2"])
-  s.add_runtime_dependency(%q<cells>, ["~> 3.4"])
+  s.add_runtime_dependency(%q<rspec-rails>)
+  s.add_runtime_dependency(%q<cells>)
 end


### PR DESCRIPTION
Hi, I want to use `rspec-cells` with higher version of RSpec and Cells.
How about relax version restriction of these gems?

(I'm trying this branch with `rspec-rails 3.0.0beta1` and `cells 3.10.0`. It works very well in my local app)
