### PR TITLE
Avoiding global configuration change

### DIFF
--- a/lib/rspec/cells/example_group.rb
+++ b/lib/rspec/cells/example_group.rb
@@ -33,13 +33,24 @@ module RSpec
 
         before do # called before every it.
           @routes = ::Rails.application.routes
-          ActionController::Base.allow_forgery_protection = false
+        end
+
+        around do |example|
+          begin
+            old_value = ActionController::Base.allow_forgery_protection
+            ActionController::Base.allow_forgery_protection = false
+
+            example.run
+
+          ensure
+            ActionController::Base.allow_forgery_protection = old_value
+          end
         end
 
         # add Example::controller and ::controller_class.
         extend RSpec::Cells::ExampleGroup::Controller
-        let (:controller_class) {  }
-        let (:controller) { controller_for(controller_class) }
+        let(:controller_class) {}
+        let(:controller) { controller_for(controller_class) }
       end
 
 


### PR DESCRIPTION
Currently, the cell example group is setting `ActionController::Base.allow_forgery_protection` to false, without setting it back to the original setting value. While `false` is rails default, we had agreed to use `true` in our system as we use a lot of custom non jquery-ujs JS and we need to test they are reading CRSF token correctly and that before block has quite screwed us for some time.

Tests should always avoid changing global objects (Well, we should avoid global objects, but can't help much for that) whenever possible.