### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/rspec-cells.gemspec
+++ b/rspec-cells.gemspec
@@ -7,10 +7,19 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Nick Sutterer"]
   s.email       = ["apotonick@gmail.com"]
-  s.homepage    = "http://rubygems.org/gems/rspec-cells"
+  s.homepage    = "https://rubygems.org/gems/rspec-cells/versions/#{s.version}"
   s.summary     = %q{Spec your cells.}
   s.description = %q{Use render_cell in your specs.}
   s.license     = 'MIT'
+
+  s.metadata = {
+    "bug_tracker_uri"   => "https://github.com/trailblazer/rspec-cells/issues",
+    "changelog_uri"     => "https://github.com/trailblazer/rspec-cells/blob/v#{s.version}/CHANGES.md",
+    "documentation_uri" => "https://www.rubydoc.info/gems/rspec-cells/#{s.version}",
+    "source_code_uri"   => "https://github.com/trailblazer/rspec-cells/tree/v#{s.version}",
+    "wiki_uri"          => "https://github.com/trailblazer/rspec-cells/wiki",
+  }
+
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }

--- a/rspec-cells.gemspec
+++ b/rspec-cells.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.metadata = {
     "bug_tracker_uri"   => "https://github.com/trailblazer/rspec-cells/issues",
-    "changelog_uri"     => "https://github.com/trailblazer/rspec-cells/blob/v#{s.version}/CHANGES.md",
+    "changelog_uri"     => "https://github.com/trailblazer/rspec-cells/blob/master/CHANGES.md",
     "documentation_uri" => "https://www.rubydoc.info/gems/rspec-cells/#{s.version}",
     "source_code_uri"   => "https://github.com/trailblazer/rspec-cells/tree/v#{s.version}",
     "wiki_uri"          => "https://github.com/trailblazer/rspec-cells/wiki",

--- a/rspec-cells.gemspec
+++ b/rspec-cells.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Nick Sutterer"]
   s.email       = ["apotonick@gmail.com"]
-  s.homepage    = "https://rubygems.org/gems/rspec-cells/versions/#{s.version}"
+  s.homepage    = "https://github.com/trailblazer/rspec-cells"
   s.summary     = %q{Spec your cells.}
   s.description = %q{Use render_cell in your specs.}
   s.license     = 'MIT'


### PR DESCRIPTION
Add `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, `source_code_uri`, and `wiki_uri` to the gemspec metadata.

These [project metadata](https://guides.rubygems.org/specification-reference/#metadata) will facilitate easy access to project information. The URI will be available on the [Rubygems project page](https://rubygems.org/gems/rspec-cells), via the rubygems API, and the `gem` and `bundle` command-line tools with the next release.

Also update the homepage URL to reference the Github repository.