### PR TITLE
Use TLS when installing gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 gemspec


### PR DESCRIPTION
To ensure gems aren't modified in transit, use TLS when downloading from Rubygems.