### PR TITLE
Allow rspec-rails v5

### DIFF
--- a/rspec-cells.gemspec
+++ b/rspec-cells.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency 'rspec-rails', '< 5.0'
+  s.add_runtime_dependency 'rspec-rails', '< 6.0'
   s.add_runtime_dependency "cells",       ">= 4.0.0", "< 6.0.0"
 
 


### PR DESCRIPTION
`rspec-rails` version 5.0.0 has been released! The only [breaking change](https://github.com/rspec/rspec-rails/blob/main/Changelog.md#500--2021-03-09) is the removal of support for Rails pre v5.2.

The `rspec-cells` test suite passes when running with `rspec-rails` v5.0.0. I think it's safe to allow.