### PR TITLE
Set Homepage URI in gem metadata

### DIFF
--- a/rspec-cells.gemspec
+++ b/rspec-cells.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
     "bug_tracker_uri"   => "https://github.com/trailblazer/rspec-cells/issues",
     "changelog_uri"     => "https://github.com/trailblazer/rspec-cells/blob/master/CHANGES.md",
     "documentation_uri" => "https://www.rubydoc.info/gems/rspec-cells/#{s.version}",
+    "homepage_uri"      => s.homepage,
     "source_code_uri"   => "https://github.com/trailblazer/rspec-cells/tree/v#{s.version}",
     "wiki_uri"          => "https://github.com/trailblazer/rspec-cells/wiki",
   }


### PR DESCRIPTION

### Context

I notice on the Rubygems page, the 'homepage' link still sends to https://rubygems.org/gems/rspec-cells.

### Change

Provide a `homepage_uri` value in the gem metadata. This should update the homepage on the Rubygems page to point to GitHub with the next gem release.