### PR TITLE
Allow rspec-rails 6.0

### DIFF
--- a/rspec-cells.gemspec
+++ b/rspec-cells.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency 'rspec-rails', '< 6.0'
+  s.add_runtime_dependency 'rspec-rails', '< 6.1'
   s.add_runtime_dependency "cells",       ">= 4.0.0", "< 6.0.0"
 
 

--- a/rspec-cells.gemspec
+++ b/rspec-cells.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency 'rspec-rails', '< 6.1'
+  s.add_runtime_dependency 'rspec-rails', ">= 3.0.0", "< 6.1.0"
   s.add_runtime_dependency "cells",       ">= 4.0.0", "< 6.0.0"
 
 


### PR DESCRIPTION
I want to use [rspec 6.0](https://github.com/rspec/rspec-rails/blob/main/Changelog.md#600--2022-10-10) with Rails7 support.

What I'm having trouble with is [this commit](https://github.com/rspec/rspec-rails/commit/b7ef894d73cbc138e5899be559ef64b53f406e7b)