### PR TITLE
Remove development and test files from the gem package

### DIFF
--- a/rspec-cells.gemspec
+++ b/rspec-cells.gemspec
@@ -21,9 +21,11 @@ Gem::Specification.new do |s|
     "wiki_uri"          => "https://github.com/trailblazer/rspec-cells/wiki",
   }
 
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").reject do |file|
+      file.start_with?(*%w[.git Appraisals Gemfile Rakefile gemfiles spec])
+    end
+  end
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency 'rspec-rails', ">= 3.0.0", "< 6.1.0"


### PR DESCRIPTION
There are a bunch of files in the gem package that aren't useful for downstream projects. Removing these reduces the gem package size from 12K to 9.5K.

```diff
< .github/workflows/ci.yml
< .gitignore
< Appraisals
  CHANGES.md
< Gemfile
  MIT-LICENSE
  README.md
< Rakefile
< gemfiles/rspec_rails_4_0.gemfile
< gemfiles/rspec_rails_5_0.gemfile
< gemfiles/rspec_rails_6_0.gemfile
  lib/generators/rspec/cell_generator.rb
  lib/generators/rspec/templates/cell_spec.erb
  lib/rspec-cells.rb
  lib/rspec/cells.rb
  lib/rspec/cells/caching.rb
  lib/rspec/cells/example_group.rb
  lib/rspec/cells/tasks.rake
  lib/rspec/cells/version.rb
  rspec-cells.gemspec
< spec/cells/caching_spec.rb
< spec/cells/cell_generator_spec.rb
< spec/cells/cell_spec_spec.rb
< spec/spec_helper.rb
```